### PR TITLE
Use MySQL 8.3.0 in Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - redmine-themes:/usr/src/redmine/public/themes
 
   mysql:
-    image: mysql:5.7
+    image: mysql:8.3.0
     container_name: mysql
     restart: always
     ports:


### PR DESCRIPTION
### Overview
This pull request contains changes to update the MySQL version from 5.7 to 8.3.0.

### Changes Made
- Modified the Dockerfile to update the MySQL version to 8.3.0.

### Testing
- Built the Docker image after the changes locally and ensured it operates correctly.

### Related Issues
There are no related issues.

### Notes
This change allows us to take advantage of new features and improvements in MySQL 8.3.0.